### PR TITLE
Fix Typo in README.md file: Missing '.'

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ A document is composed of a multitude of records (instances of a `Fixy::Record`)
 class PeopleDocument < Fixy::Document
   def build
     append_record  PersonRecord.new('Sarah', 'Kerrigan')
-    append_record  PersonRecordnew('Jim', 'Raynor')
+    append_record  PersonRecord.new('Jim', 'Raynor')
     prepend_record PersonRecord.new('Arcturus', 'Mengsk')
   end
 end


### PR DESCRIPTION
While reading the documentation, I noticed that you were missing a period in one of your examples.
