### PR TITLE
Remove ActiveSupport dependency

### DIFF
--- a/fixy.gemspec
+++ b/fixy.gemspec
@@ -21,5 +21,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
 
   spec.add_runtime_dependency 'rake'
-  spec.add_runtime_dependency 'activesupport'
 end


### PR DESCRIPTION
Remove ActiveSupport dependency now that we don't need `Proc#bind`. Yay, lightweight!
