### PR TITLE
Allow definition and value to be specified by Record.field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ test/tmp
 test/version_tmp
 tmp
 /pmip
+.ruby-version
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.3
+
+* Allow passing block to field to define field_value
+* Update handling of multi-byte characters
+
 ## v0.0.2
 
 * Fixed typos in README

--- a/lib/fixy/record.rb
+++ b/lib/fixy/record.rb
@@ -32,6 +32,8 @@ module Fixy
 
         # We're good to go :)
         @record_fields[range_from] = { name: name, from: range_from, to: range_to, size: size, type: type}
+
+        field_value(name, Proc.new) if block_given?
       end
 
       # Convenience method for creating field methods

--- a/lib/fixy/version.rb
+++ b/lib/fixy/version.rb
@@ -1,3 +1,3 @@
 module Fixy
-  VERSION = "0.0.2"
+  VERSION = '0.0.3'
 end

--- a/spec/fixy/record_spec.rb
+++ b/spec/fixy/record_spec.rb
@@ -57,24 +57,29 @@ end
 
 describe 'Generating a Record' do
   context 'when properly defined' do
-    it 'should generate fixed width record' do
-      class PersonRecordE < Fixy::Record
-        include Fixy::Formatter::Alphanumeric
+    class PersonRecordE < Fixy::Record
+      include Fixy::Formatter::Alphanumeric
 
-        set_record_length 20
+      set_record_length 20
 
-        field :first_name, 10, '1-10' , :alphanumeric
-        field :last_name , 10, '11-20', :alphanumeric
+      field :first_name, 10, '1-10' , :alphanumeric
+      field :last_name , 10, '11-20', :alphanumeric
 
-        field_value :first_name, -> { 'Sarah' }
+      field_value :first_name, -> { 'Sarah' }
 
-        def last_name
-          'Kerrigan'
-        end
+      def last_name
+        'Kerrigan'
       end
+    end
 
+    it 'should generate fixed width record' do
       PersonRecordE.new.generate.should eq "Sarah     Kerrigan  \n"
-      PersonRecordE.new.generate(true).should eq File.read('spec/fixtures/debug_record.txt')
+    end
+
+    context 'when using the debug flag' do
+      it 'should produce a debug log' do
+        PersonRecordE.new.generate(true).should eq File.read('spec/fixtures/debug_record.txt')
+      end
     end
   end
 
@@ -149,6 +154,18 @@ describe 'Generating a Record' do
         PersonRecordI.new.generate.slice(0, 10).should eq 'Bob       '
         PersonRecordI.new.generate.slice(10, 10).should eq 'Jacobs    '
       end
+    end
+  end
+
+  context 'when a block is passed to field' do
+    class PersonRecordJ < Fixy::Record
+      include Fixy::Formatter::Alphanumeric
+      set_record_length 20
+      field(:description , 20, '1-20', :alphanumeric) { 'Use My Value' }
+    end
+
+    it 'uses the proc conversion as the field value' do
+      PersonRecordJ.new.generate.should eq('Use My Value'.ljust(20) << "\n")
     end
   end
 end


### PR DESCRIPTION
Optionally specify `Record.field_value` by passing a block to `Record.field`