### PR TITLE
Alphanumeric formatter would not chop multibyte chars unexpectedly

### DIFF
--- a/lib/fixy/formatter/alphanumeric.rb
+++ b/lib/fixy/formatter/alphanumeric.rb
@@ -9,15 +9,22 @@ module Fixy
       # left-justified and filled with spaces.
       #
 
-      def format_alphanumeric(input, bytes)
-        input_string = String.new(input.to_s)
-        truncated_bytesize = [input_string.bytesize, bytes].min
-        if truncated_bytesize < bytes
-          input_string << " " * (bytes - truncated_bytesize)
-          input_string
+      def format_alphanumeric(input, byte_width)
+        result = ''
+
+        if input.bytesize <= byte_width
+          result = input.dup
         else
-          input_string.byteslice(0..(truncated_bytesize - 1))
+          input.each_char do |char|
+            if result.bytesize + char.bytesize <= byte_width
+              result << char
+            else
+              break
+            end
+          end
         end
+
+        result << " " * (byte_width - result.bytesize)
       end
     end
   end

--- a/spec/fixy/record_spec.rb
+++ b/spec/fixy/record_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'spec_helper'
 
 describe 'Defining a Record' do
@@ -86,7 +87,7 @@ describe 'Generating a Record' do
 
         field :name, 9, '1-9' , :alphanumeric
 
-        field_value :name, -> { "12345678И"  }
+        field_value :name, -> { "12345678И" }
       end
 
       value = PersonRecordMultibyte.new.generate

--- a/spec/fixy/record_spec.rb
+++ b/spec/fixy/record_spec.rb
@@ -86,11 +86,12 @@ describe 'Generating a Record' do
 
         field :name, 9, '1-9' , :alphanumeric
 
-        field_value :name, -> { "Тарас Иванов"  }
+        field_value :name, -> { "сараТ вонавИ"  }
       end
 
       value = PersonRecordMultibyte.new.generate
       value.should be_valid_encoding
+      value.should == "сара \n"
     end
   end
 

--- a/spec/fixy/record_spec.rb
+++ b/spec/fixy/record_spec.rb
@@ -86,12 +86,12 @@ describe 'Generating a Record' do
 
         field :name, 9, '1-9' , :alphanumeric
 
-        field_value :name, -> { "сараТ вонавИ"  }
+        field_value :name, -> { "12345678И"  }
       end
 
       value = PersonRecordMultibyte.new.generate
       value.should be_valid_encoding
-      value.should == "сара \n"
+      value.should == "12345678 \n"
     end
   end
 

--- a/spec/fixy/record_spec.rb
+++ b/spec/fixy/record_spec.rb
@@ -77,6 +77,23 @@ describe 'Generating a Record' do
     end
   end
 
+  context 'when dealing with multi-byte characters' do
+    it 'should generate fixed width record' do
+      class PersonRecordMultibyte < Fixy::Record
+        include Fixy::Formatter::Alphanumeric
+
+        set_record_length 9
+
+        field :name, 9, '1-9' , :alphanumeric
+
+        field_value :name, -> { "Тарас Иванов"  }
+      end
+
+      value = PersonRecordMultibyte.new.generate
+      value.should be_valid_encoding
+    end
+  end
+
   context 'when definition is incomplete (e.g. undefined columns)' do
     it 'should raise an error' do
       class PersonRecordF < Fixy::Record


### PR DESCRIPTION
This is to fix breaking the multibyte chars