### PR TITLE
Add custom line endings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ test/version_tmp
 tmp
 /pmip
 .ruby-version
-
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -208,6 +208,14 @@ end
 ```
 
 
+## Custom line endings
+
+The default line ending is '\n' (Linux/OSX standard). A different line ending can be applied by passing it as the 2nd argument to the Document's generate method.  For example, if you wanted to generate a document without debug_mode and apply Windows standard line endings, you would do this:
+
+```ruby
+PeopleDocument.new.generate(false, '\r\n')
+```
+
 
 ## Contributing
 

--- a/lib/fixy/document.rb
+++ b/lib/fixy/document.rb
@@ -1,7 +1,7 @@
 module Fixy
   class Document
 
-    attr_accessor :content, :debug_mode
+    attr_accessor :content, :debug_mode, :line_ending
 
     def generate_to_file(path, debug = false)
       File.open(path, 'w') do |file|
@@ -9,8 +9,9 @@ module Fixy
       end
     end
 
-    def generate(debug = false)
+    def generate(debug = false, line_ending = "\n")
       @debug_mode = debug
+      @line_ending = line_ending
       @content = ''
 
       # Generate document based on user logic.
@@ -30,15 +31,15 @@ module Fixy
     end
 
     def prepend_record(record)
-      @content = record.generate(debug_mode) << @content
+      @content = record.generate(debug_mode, line_ending) << @content
     end
 
     def append_record(record)
-      @content << record.generate(debug_mode)
+      @content << record.generate(debug_mode, line_ending)
     end
 
     def parse_record(klass, record)
-      @content << klass.parse(record, debug_mode)[:record]
+      @content << klass.parse(record, debug_mode, line_ending)[:record]
     end
   end
 end

--- a/lib/fixy/record.rb
+++ b/lib/fixy/record.rb
@@ -64,7 +64,7 @@ module Fixy
       end
 
       # Parse an existing record
-      def parse(record, debug = false)
+      def parse(record, debug = false, line_ending = "\n")
         raise ArgumentError, 'Record must be a string'  unless record.is_a? String
 
         unless record.length == record_length
@@ -97,14 +97,14 @@ module Fixy
         end
 
         # Documentation mandates that every record ends with new line.
-        output << "\n"
+        output << line_ending
 
         { fields: fields, record: decorator.record(output) }
       end
     end
 
     # Generate the entry based on the record structure
-    def generate(debug = false)
+    def generate(debug = false, line_ending = "\n")
       decorator = debug ? Fixy::Decorator::Debug : Fixy::Decorator::Default
       output = ''
       current_position = 1
@@ -127,7 +127,7 @@ module Fixy
       end
 
       # Documentation mandates that every record ends with new line.
-      output << "\n"
+      output << line_ending
 
       # All ready. In the words of Mr. Peters: "Take it and go!"
       decorator.record(output)

--- a/spec/fixtures/debug_document_custom_line_endings.txt
+++ b/spec/fixtures/debug_document_custom_line_endings.txt
@@ -1,0 +1,50 @@
+<html>
+            <head>
+              <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
+              <script src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+              <style>
+                body  { margin: 0; padding: 0; background-color: #CDCDCD; }
+                pre   { margin: 0; }
+                .even { background-color: #ABABAB; }
+                .odd  { background-color: #CDCDCD; }
+                b     { font-size: 15px; }
+                .line { width: 50px; text-align: right; margin-right: 10px; color: #7f8284; display: inline-block; background-color: #272822; padding-right: 5px;}
+                span:hover { background-color: yellow; }
+                span.line:hover { background-color: #3e3d32; }
+                .tooltip        { min-width: 250px; position: absolute; z-index: 1030; display: block; font-size: 12px; line-height: 1.4; visibility: visible; filter: alpha(opacity=0); opacity: 0; }
+                .tooltip.in     { filter: alpha(opacity=90); opacity: .9; }
+                .tooltip.bottom { padding: 5px 0; margin-top: 3px; }
+                .tooltip-inner  {  max-width: 200px; padding: 3px 8px;  color: #fff; text-align: center;  text-decoration: none; background-color: #000; border-radius: 4px; }
+                .tooltip-arrow  { position: absolute; width: 0; height: 0; border-color: transparent; border-style: solid; }
+                .tooltip.bottom .tooltip-arrow { top: 0; left: 50%; margin-left: -5px; border-width: 0 5px 5px; border-bottom-color: #000; }
+              </style>
+              <script type="text/javascript">
+                $(document).ready(function() {
+                    $("div").each(function(i, div) {
+                        $div = $(div);
+                        $spans = $div.find("span");
+                        $spans.each(function(j, span) {
+                            element = $(span);
+                            method = element.data("method");
+                            size = element.data("size");
+                            format = element.data("format");
+                            column = element.data("column");
+                            line = i + 1;
+
+                            $(element).tooltip({
+                                title: ("<b>" + method + "</b><br/>Line: " + line + "<br/>Column: " + column + "<br/>Length: " + size + "<br/>Formatter: " + format),
+                                placement: "bottom",
+                                container: "body",
+                                html: true
+                            });
+                        });
+                        $div.find("pre").prepend("<span class='line'>" + (i + 1) + "</span>");
+                    });
+                });
+              </script>
+            </head>
+            <body><div><pre><span class='odd' data-column='1' data-method='first_name' data-size='10' data-format='alphanumeric'>Arcturus  </span><span class='even' data-column='11' data-method='last_name' data-size='10' data-format='alphanumeric'>Mengsk    </span>
+</pre></div><div><pre><span class='odd' data-column='1' data-method='first_name' data-size='10' data-format='alphanumeric'>Sarah     </span><span class='even' data-column='11' data-method='last_name' data-size='10' data-format='alphanumeric'>Kerrigan  </span>
+</pre></div><div><pre><span class='odd' data-column='1' data-method='first_name' data-size='10' data-format='alphanumeric'>Jim       </span><span class='even' data-column='11' data-method='last_name' data-size='10' data-format='alphanumeric'>Raynor    </span>
+</pre></div></body>
+          </html>

--- a/spec/fixy/document_spec.rb
+++ b/spec/fixy/document_spec.rb
@@ -50,5 +50,10 @@ describe 'Defining a Document' do
       ParsedPeopleDocument.new.generate.should eq "Arcturus  Mengsk    \nSarah     Kerrigan  \nJim       Raynor    \n"
       ParsedPeopleDocument.new.generate(true).should eq File.read('spec/fixtures/debug_document.txt')
     end
+
+    it 'should apply custom line endings if given' do
+      ParsedPeopleDocument.new.generate(false, "\r\n").should eq "Arcturus  Mengsk    \r\nSarah     Kerrigan  \r\nJim       Raynor    \r\n"
+      ParsedPeopleDocument.new.generate(true, "\r\n").should eq File.read('spec/fixtures/debug_document_custom_line_endings.txt')
+    end
   end
 end


### PR DESCRIPTION
Added a way to apply custom line endings when calling "generate" on a document.  This is most useful for applying Windows \r\n endings.  Also added tests for this functionality.