### PR TITLE
Support for multi-byte record parsing

### DIFF
--- a/lib/fixy/record.rb
+++ b/lib/fixy/record.rb
@@ -87,7 +87,7 @@ module Fixy
           from   = field[:from] - 1
           to     = field[:to]   - 1
           method = field[:name]
-          value  = byte_record[from..to].pack('C*').force_encoding('utf-8')
+          value  = byte_record[from..to].to_a.pack('C*').force_encoding('utf-8')
 
           formatted_value = decorator.field(value, current_record, current_position, method, field[:size], field[:type])
           output << formatted_value

--- a/lib/fixy/record.rb
+++ b/lib/fixy/record.rb
@@ -77,7 +77,7 @@ module Fixy
         current_position = 1
         current_record = 1
 
-        byte_record = record.bytes
+        byte_record = record.bytes.to_a
         while current_position <= record_length do
 
           field = record_fields[current_position]
@@ -87,7 +87,7 @@ module Fixy
           from   = field[:from] - 1
           to     = field[:to]   - 1
           method = field[:name]
-          value  = byte_record[from..to].to_a.pack('C*').force_encoding('utf-8')
+          value  = byte_record[from..to].pack('C*').force_encoding('utf-8')
 
           formatted_value = decorator.field(value, current_record, current_position, method, field[:size], field[:type])
           output << formatted_value

--- a/lib/fixy/record.rb
+++ b/lib/fixy/record.rb
@@ -67,7 +67,7 @@ module Fixy
       def parse(record, debug = false)
         raise ArgumentError, 'Record must be a string'  unless record.is_a? String
 
-        unless record.length == record_length
+        unless record.bytesize == record_length
           raise ArgumentError, "Record length is invalid (Expected #{record_length})"
         end
 
@@ -77,6 +77,7 @@ module Fixy
         current_position = 1
         current_record = 1
 
+        byte_record = record.bytes
         while current_position <= record_length do
 
           field = record_fields[current_position]
@@ -86,7 +87,7 @@ module Fixy
           from   = field[:from] - 1
           to     = field[:to]   - 1
           method = field[:name]
-          value  = record[from..to]
+          value  = byte_record[from..to].pack('C*').force_encoding('utf-8')
 
           formatted_value = decorator.field(value, current_record, current_position, method, field[:size], field[:type])
           output << formatted_value

--- a/spec/fixtures/debug_parsed_multibyte_record.txt
+++ b/spec/fixtures/debug_parsed_multibyte_record.txt
@@ -1,0 +1,2 @@
+<div><pre><span class='odd' data-column='1' data-method='first_name' data-size='10' data-format='alphanumeric'>älimuk   </span><span class='even' data-column='11' data-method='last_name' data-size='10' data-format='alphanumeric'>Karil     </span>
+</pre></div>

--- a/spec/fixy/record_spec.rb
+++ b/spec/fixy/record_spec.rb
@@ -188,6 +188,25 @@ describe 'Generating a Record' do
 end
 
 describe 'Parsing a record' do
+  let(:multibyte_record) { 'älimuk   Karil     ' }
+  context 'with a record of multi-byte characters' do
+    it 'should not raise with the right number of bytes' do
+      PersonRecordE.parse(multibyte_record, true).should eq({
+        record: File.read('spec/fixtures/debug_parsed_multibyte_record.txt'),
+      fields: [
+        { name: :first_name, value: 'älimuk   '},
+        { name: :last_name,  value: 'Karil     '}
+      ]
+      })
+    end
+
+    it 'should not raise with the right amount' do
+      expect {
+        PersonRecordE.parse('älimuk  Karil     ', true)
+      }.to raise_error(StandardError, 'Record length is invalid (Expected 20)')
+    end
+  end
+
   context 'when properly defined' do
     let(:record) { "Sarah     Kerrigan  " }
     class PersonRecordK < Fixy::Record


### PR DESCRIPTION
Since records are required to be some amount of bytes, not a set amount of characters, I've made parsing take byte length into account, not character length, while still parsing the records on the right boundaries.