### PR TITLE
Improve field length enforcement

### DIFF
--- a/lib/fixy/decorator/debug.rb
+++ b/lib/fixy/decorator/debug.rb
@@ -8,7 +8,7 @@ module Fixy
               <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
               <script src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
               <style>
-                body  { margin: 0; padding: 0; background-color: #CDCDCD; }
+                body  { margin: 0; padding: 0; background-color: #EFEFEF; }
                 pre   { margin: 0; }
                 .even { background-color: #ABABAB; }
                 .odd  { background-color: #CDCDCD; }

--- a/lib/fixy/record.rb
+++ b/lib/fixy/record.rb
@@ -133,7 +133,13 @@ module Fixy
         # We will first retrieve the value, then format it
         method          = field[:name]
         value           = send(method)
-        formatted_value = format_value(value, field[:size], field[:type])
+
+        begin
+          formatted_value = format_value(value, field[:size], field[:type])
+        rescue => e
+          raise $!, "Error while formatting `#{field[:name]}` -- #{$!}", $!.backtrace
+        end
+
         formatted_value = decorator.field(formatted_value, current_record, current_position, method, field[:size], field[:type])
 
         output << formatted_value

--- a/lib/fixy/record.rb
+++ b/lib/fixy/record.rb
@@ -140,6 +140,8 @@ module Fixy
           raise $!, "Error while formatting `#{field[:name]}` -- #{$!}", $!.backtrace
         end
 
+        raise StandardError, "formatted value for `#{field[:name]}` violates size constraint (expected: #{field[:size]}, actual: #{formatted_value.length}), formatter: #{field[:type]}" if formatted_value.length != field[:size]
+
         formatted_value = decorator.field(formatted_value, current_record, current_position, method, field[:size], field[:type])
 
         output << formatted_value

--- a/spec/fixtures/debug_document.txt
+++ b/spec/fixtures/debug_document.txt
@@ -3,7 +3,7 @@
               <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
               <script src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
               <style>
-                body  { margin: 0; padding: 0; background-color: #CDCDCD; }
+                body  { margin: 0; padding: 0; background-color: #EFEFEF; }
                 pre   { margin: 0; }
                 .even { background-color: #ABABAB; }
                 .odd  { background-color: #CDCDCD; }

--- a/spec/fixy/record_spec.rb
+++ b/spec/fixy/record_spec.rb
@@ -58,6 +58,30 @@ describe 'Defining a Record' do
 end
 
 describe 'Generating a Record' do
+
+  context 'when formatting field values' do
+
+    class PersonRecordWithInvalidFormatter < Fixy::Record
+      include Fixy::Formatter::Alphanumeric
+
+      set_record_length 20
+
+      def format_incorrect(input, length)
+        'X' * (length * 2)
+      end
+
+      field :first_name, 10, '1-10' , :alphanumeric
+      field :last_name , 10, '11-20', :incorrect
+
+      field_value :first_name, -> { 'Bob' }
+      field_value :last_name, -> { 'Smith' }
+    end
+
+    it 'should raise an error if the formatter returns a string longer than the field size' do
+      expect { PersonRecordWithInvalidFormatter.new.generate }.to raise_error(StandardError)
+    end
+  end
+
   context 'when properly defined' do
     class PersonRecordE < Fixy::Record
       include Fixy::Formatter::Alphanumeric


### PR DESCRIPTION
Thanks for building Fixy! 

This PR attempts to improve some issues we encountered with formatters.

Specifically:
- Due to our inheritance pattern and formatter re-use, it was difficult to track down the specific fields that caused exceptions to arise from formatters, so we now salt the raised exception with some added context.
- We then discovered a formatter that was returning a string longer than a given field's size constraint; when encountering this during record generation, raise an exception.
- One of the tools we used to identify the issue was the debug HTML decorator. Changing the generated page's `background-color` CSS property to something other than the fields' background color allowed us to easily spot records that exceeded the record length.

Cheers! :beers: 
